### PR TITLE
[feat] 커뮤니티 기본 도메인 CRUD 추가

### DIFF
--- a/src/main/java/com/example/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/backend/domain/post/controller/PostController.java
@@ -29,4 +29,17 @@ public class PostController {
     public ResponseEntity<PostResponseDto> getPost(@PathVariable Long postId) {
         return ResponseEntity.ok(postService.getPost(postId));
     }
+
+    @PutMapping("/{postId}")
+    public ResponseEntity<PostResponseDto> updatePost(
+            @PathVariable Long postId,
+            @RequestBody PostRequestDto requestDto) {
+        return ResponseEntity.ok(postService.updatePost(postId, requestDto));
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long postId) {
+        postService.deletePost(postId);
+        return ResponseEntity.noContent().build(); // // 204 No Content 반환
+    }
 }

--- a/src/main/java/com/example/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/backend/domain/post/controller/PostController.java
@@ -1,0 +1,32 @@
+package com.example.backend.domain.post.controller;
+
+import com.example.backend.domain.post.dto.PostRequestDto;
+import com.example.backend.domain.post.dto.PostResponseDto;
+import com.example.backend.domain.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<PostResponseDto> createPost(@RequestBody PostRequestDto dto, @RequestParam Long userId) {
+        return ResponseEntity.ok(postService.createPost(dto, userId));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PostResponseDto>> getAllPosts() {
+        return ResponseEntity.ok(postService.getAllPosts());
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostResponseDto> getPost(@PathVariable Long postId) {
+        return ResponseEntity.ok(postService.getPost(postId));
+    }
+}

--- a/src/main/java/com/example/backend/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/com/example/backend/domain/post/dto/PostRequestDto.java
@@ -1,11 +1,13 @@
 package com.example.backend.domain.post.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class PostRequestDto {
     private String title;
     private String content;

--- a/src/main/java/com/example/backend/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/com/example/backend/domain/post/dto/PostRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.backend.domain.post.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PostRequestDto {
+    private String title;
+    private String content;
+    private List<Long> categoryIds;
+}

--- a/src/main/java/com/example/backend/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/example/backend/domain/post/dto/PostResponseDto.java
@@ -1,0 +1,36 @@
+package com.example.backend.domain.post.dto;
+
+import com.example.backend.domain.post.entity.PostEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class PostResponseDto {
+    private Long postId;
+    private String title;
+    private String content;
+    private String authorName;
+    private Integer viewCount;
+    private Integer likeCount;
+    private List<String> categories;
+    private LocalDateTime createdAt;
+
+    public static PostResponseDto from(PostEntity post) {
+        return new PostResponseDto(
+                post.getPostId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getUser().getName(),
+                post.getViewCount(),
+                post.getLikeCount(),
+                post.getPostClassifications().stream()
+                        .map(pc -> pc.getCategory().getName())
+                        .collect(Collectors.toList()),
+                post.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/backend/domain/post/entity/PostClassificationEntity.java
+++ b/src/main/java/com/example/backend/domain/post/entity/PostClassificationEntity.java
@@ -1,0 +1,26 @@
+package com.example.backend.domain.post.entity;
+
+import com.example.backend.domain.category.entity.CategoryEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "post_classification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PostClassificationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private PostEntity post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private CategoryEntity category;
+}

--- a/src/main/java/com/example/backend/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/example/backend/domain/post/entity/PostEntity.java
@@ -1,0 +1,50 @@
+package com.example.backend.domain.post.entity;
+
+import com.example.backend.domain.user.entity.UserEntity;
+import com.example.backend.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "posts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PostEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Builder.Default
+    private Integer viewCount = 0;
+
+    @Builder.Default
+    private Integer likeCount = 0;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostClassificationEntity> postClassifications = new ArrayList<>();
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+}

--- a/src/main/java/com/example/backend/domain/post/repository/PostClassificationRepository.java
+++ b/src/main/java/com/example/backend/domain/post/repository/PostClassificationRepository.java
@@ -1,0 +1,10 @@
+package com.example.backend.domain.post.repository;
+
+import com.example.backend.domain.post.entity.PostClassificationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostClassificationRepository extends JpaRepository<PostClassificationEntity, Long> {
+
+    // 1. 게시판 및 카테고리 매핑
+
+}

--- a/src/main/java/com/example/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/backend/domain/post/repository/PostRepository.java
@@ -1,0 +1,12 @@
+package com.example.backend.domain.post.repository;
+
+import com.example.backend.domain.post.entity.PostEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<PostEntity, Long> {
+
+    // 1. 기본 CRUD 제공
+
+}

--- a/src/main/java/com/example/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/example/backend/domain/post/service/PostService.java
@@ -58,4 +58,31 @@ public class PostService {
         post.increaseViewCount();
         return PostResponseDto.from(post);
     }
+
+    @Transactional
+    public PostResponseDto updatePost(Long postId, PostRequestDto requestDto) {
+        PostEntity post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+
+        // // 2. 제목 및 내용 업데이트
+        post.update(requestDto.getTitle(), requestDto.getContent());
+
+        // // 3. 기존 카테고리 매핑 삭제 후 재등록 (선택 사항)
+        if (requestDto.getCategoryIds() != null) {
+            post.getPostClassifications().clear(); // // OrphanRemoval 설정으로 인해 DB에서도 자동 삭제됨
+            requestDto.getCategoryIds().forEach(id -> {
+                CategoryEntity category = categoryRepository.findById(id)
+                        .orElseThrow(() -> new IllegalArgumentException("카테고리 없음"));
+                postClassificationRepository.save(PostClassificationEntity.builder()
+                        .post(post).category(category).build());
+            });
+        }
+        return PostResponseDto.from(post);
+    }
+
+    // // 4. 게시글 삭제
+    @Transactional
+    public void deletePost(Long postId) {
+        postRepository.deleteById(postId);
+    }
 }

--- a/src/main/java/com/example/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/example/backend/domain/post/service/PostService.java
@@ -64,12 +64,10 @@ public class PostService {
         PostEntity post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
 
-        // // 2. 제목 및 내용 업데이트
         post.update(requestDto.getTitle(), requestDto.getContent());
 
-        // // 3. 기존 카테고리 매핑 삭제 후 재등록 (선택 사항)
         if (requestDto.getCategoryIds() != null) {
-            post.getPostClassifications().clear(); // // OrphanRemoval 설정으로 인해 DB에서도 자동 삭제됨
+            post.getPostClassifications().clear();
             requestDto.getCategoryIds().forEach(id -> {
                 CategoryEntity category = categoryRepository.findById(id)
                         .orElseThrow(() -> new IllegalArgumentException("카테고리 없음"));

--- a/src/main/java/com/example/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/example/backend/domain/post/service/PostService.java
@@ -1,0 +1,61 @@
+package com.example.backend.domain.post.service;
+
+import com.example.backend.domain.category.entity.CategoryEntity;
+import com.example.backend.domain.category.repository.CategoryRepository;
+import com.example.backend.domain.post.dto.PostRequestDto;
+import com.example.backend.domain.post.dto.PostResponseDto;
+import com.example.backend.domain.post.entity.PostClassificationEntity;
+import com.example.backend.domain.post.entity.PostEntity;
+import com.example.backend.domain.post.repository.PostClassificationRepository;
+import com.example.backend.domain.post.repository.PostRepository;
+import com.example.backend.domain.user.entity.UserEntity;
+import com.example.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+    private final PostClassificationRepository postClassificationRepository;
+
+    @Transactional
+    public PostResponseDto createPost(PostRequestDto requestDto, Long userId) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        PostEntity post = postRepository.save(PostEntity.builder()
+                .user(user)
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .build());
+
+        if (requestDto.getCategoryIds() != null) {
+            requestDto.getCategoryIds().forEach(id -> {
+                CategoryEntity category = categoryRepository.findById(id)
+                        .orElseThrow(() -> new IllegalArgumentException("카테고리 없음: " + id));
+                postClassificationRepository.save(PostClassificationEntity.builder()
+                        .post(post).category(category).build());
+            });
+        }
+        return PostResponseDto.from(post);
+    }
+
+    public List<PostResponseDto> getAllPosts() {
+        return postRepository.findAll().stream().map(PostResponseDto::from).toList();
+    }
+
+    @Transactional
+    public PostResponseDto getPost(Long postId) {
+        PostEntity post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글 없음"));
+        post.increaseViewCount();
+        return PostResponseDto.from(post);
+    }
+}

--- a/src/test/java/com/example/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/backend/domain/post/service/PostServiceTest.java
@@ -1,0 +1,112 @@
+package com.example.backend.domain.post.service;
+
+import com.example.backend.domain.category.entity.CategoryEntity;
+import com.example.backend.domain.category.repository.CategoryRepository;
+import com.example.backend.domain.post.dto.PostRequestDto;
+import com.example.backend.domain.post.dto.PostResponseDto;
+import com.example.backend.domain.post.entity.PostEntity;
+import com.example.backend.domain.post.repository.PostClassificationRepository;
+import com.example.backend.domain.post.repository.PostRepository;
+import com.example.backend.domain.user.entity.UserEntity;
+import com.example.backend.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private CategoryRepository categoryRepository;
+    @Mock
+    private PostClassificationRepository postClassificationRepository;
+
+    @InjectMocks
+    private PostService postService;
+
+    // // 1. 게시글 생성 테스트
+    @Test
+    @DisplayName("게시글 생성 - 성공 (카테고리 포함)")
+    void createPost_Success() {
+        // given
+        Long userId = 1L;
+        UserEntity user = UserEntity.builder().userId(userId).name("유시영").build();
+        CategoryEntity category = CategoryEntity.builder().categoryId(10L).name("자유게시판").build();
+
+        PostRequestDto request = new PostRequestDto("테스트 제목", "테스트 내용", List.of(10L));
+        PostEntity savedPost = PostEntity.builder().postId(100L).user(user).title("테스트 제목").build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(postRepository.save(any(PostEntity.class))).willReturn(savedPost);
+        given(categoryRepository.findById(10L)).willReturn(Optional.of(category));
+
+        // when
+        PostResponseDto result = postService.createPost(request, userId);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo("테스트 제목");
+        assertThat(result.getAuthorName()).isEqualTo("유시영");
+        verify(postRepository, times(1)).save(any(PostEntity.class));
+        verify(postClassificationRepository, times(1)).save(any());
+    }
+
+    // // 2. 게시글 상세 조회 테스트 (조회수 증가 확인)
+    @Test
+    @DisplayName("게시글 상세 조회 - 성공 및 조회수 증가")
+    void getPost_Success() {
+        // given
+        Long postId = 100L;
+        UserEntity user = UserEntity.builder().name("유시영").build();
+        PostEntity post = PostEntity.builder()
+                .postId(postId)
+                .user(user)
+                .title("조회수 테스트")
+                .viewCount(0)
+                .build();
+
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+        // when
+        PostResponseDto result = postService.getPost(postId);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo("조회수 테스트");
+        assertThat(post.getViewCount()).isEqualTo(1); // // 서비스 로직 내 increaseViewCount() 검증
+    }
+
+    // // 3. 게시글 전체 조회 테스트
+    @Test
+    @DisplayName("게시글 전체 목록 조회 - 성공")
+    void getAllPosts_Success() {
+        // given
+        UserEntity user = UserEntity.builder().name("유시영").build();
+        List<PostEntity> posts = List.of(
+                PostEntity.builder().postId(1L).user(user).title("제목1").build(),
+                PostEntity.builder().postId(2L).user(user).title("제목2").build()
+        );
+        given(postRepository.findAll()).willReturn(posts);
+
+        // when
+        List<PostResponseDto> result = postService.getAllPosts();
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getTitle()).isEqualTo("제목1");
+    }
+}

--- a/src/test/java/com/example/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/backend/domain/post/service/PostServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -116,7 +117,14 @@ class PostServiceTest {
     void updatePost_Success() {
         // given
         Long postId = 1L;
-        PostEntity post = PostEntity.builder().postId(postId).title("원래 제목").build();
+        UserEntity user = UserEntity.builder().name("유시영").build();
+        PostEntity post = PostEntity.builder()
+                .postId(postId)
+                .user(user)
+                .title("원래 제목")
+                .postClassifications(new ArrayList<>())
+                .build();
+
         PostRequestDto request = new PostRequestDto("바뀐 제목", "바뀐 내용", null);
 
         given(postRepository.findById(postId)).willReturn(Optional.of(post));
@@ -126,6 +134,7 @@ class PostServiceTest {
 
         // then
         assertThat(result.getTitle()).isEqualTo("바뀐 제목");
+        assertThat(result.getAuthorName()).isEqualTo("유시영");
     }
 
     // 5. 게시글 삭제 테스트

--- a/src/test/java/com/example/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/backend/domain/post/service/PostServiceTest.java
@@ -40,7 +40,7 @@ class PostServiceTest {
     @InjectMocks
     private PostService postService;
 
-    // // 1. 게시글 생성 테스트
+    // 1. 게시글 생성 테스트
     @Test
     @DisplayName("게시글 생성 - 성공 (카테고리 포함)")
     void createPost_Success() {
@@ -66,7 +66,7 @@ class PostServiceTest {
         verify(postClassificationRepository, times(1)).save(any());
     }
 
-    // // 2. 게시글 상세 조회 테스트 (조회수 증가 확인)
+    // 2. 게시글 상세 조회 테스트 (조회수 증가 확인)
     @Test
     @DisplayName("게시글 상세 조회 - 성공 및 조회수 증가")
     void getPost_Success() {
@@ -90,7 +90,7 @@ class PostServiceTest {
         assertThat(post.getViewCount()).isEqualTo(1); // // 서비스 로직 내 increaseViewCount() 검증
     }
 
-    // // 3. 게시글 전체 조회 테스트
+    // 3. 게시글 전체 조회 테스트
     @Test
     @DisplayName("게시글 전체 목록 조회 - 성공")
     void getAllPosts_Success() {
@@ -108,5 +108,37 @@ class PostServiceTest {
         // then
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getTitle()).isEqualTo("제목1");
+    }
+
+    // 4. 게시글 수정 테스트
+    @Test
+    @DisplayName("게시글 수정 - 성공")
+    void updatePost_Success() {
+        // given
+        Long postId = 1L;
+        PostEntity post = PostEntity.builder().postId(postId).title("원래 제목").build();
+        PostRequestDto request = new PostRequestDto("바뀐 제목", "바뀐 내용", null);
+
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+        // when
+        PostResponseDto result = postService.updatePost(postId, request);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo("바뀐 제목");
+    }
+
+    // 5. 게시글 삭제 테스트
+    @Test
+    @DisplayName("게시글 삭제 - 성공")
+    void deletePost_Success() {
+        // given
+        Long postId = 1L;
+
+        // when
+        postService.deletePost(postId);
+
+        // then
+        verify(postRepository, times(1)).deleteById(postId);
     }
 }


### PR DESCRIPTION
## 🎯 이슈 번호
- #28 

## ⚙️ 변경 내용
- 게시글 관련 기능 추가

## ✉️ 상세 내용
- 게시글 기본 도메인 CRUD 추가
- 게시글 관련 카테고리 연동

## 🖥️ 테스트
> 기본 도메인 테스트 성공
<img width="893" height="392" alt="image" src="https://github.com/user-attachments/assets/1fdacaa7-c3d6-46e4-bb2b-4170fb7385ae" />
