### PR TITLE
[FEAT] AWS S3 이미지 업로드 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 
     // 스프링 시큐리티 (비밀번호 암호화용)
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // AWS S3 연동을 위한 라이브러리
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
 }
 
 test {

--- a/src/main/java/com/example/backend/domain/image/controller/ImageController.java
+++ b/src/main/java/com/example/backend/domain/image/controller/ImageController.java
@@ -1,0 +1,30 @@
+package com.example.backend.domain.image.controller;
+
+import com.example.backend.global.common.ApiResponse;
+import com.example.backend.global.config.s3.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final S3Service s3Service;
+
+    // 1. 이미지 단건 업로드 API
+    @PostMapping("/upload")
+    public ResponseEntity<ApiResponse<String>> uploadImage(@RequestParam("file") MultipartFile file) {
+        // 2. 파일이 비어있는지 간단 체크
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+        }
+
+        String imageUrl = s3Service.uploadImage(file);
+
+        // 3. 공통 응답 포맷에 담아 리턴
+        return ResponseEntity.ok(ApiResponse.success(200, imageUrl));
+    }
+}

--- a/src/main/java/com/example/backend/global/config/s3/S3Service.java
+++ b/src/main/java/com/example/backend/global/config/s3/S3Service.java
@@ -15,23 +15,43 @@ public class S3Service {
 
     private final S3Template s3Template;
 
+    // 1. S3 버킷 이름 주입
     @Value("${spring.cloud.aws.s3.bucket}")
-    private String bucket; // 1. yusiyeong-media-bucket-2026 주입
+    private String bucket;
 
-    // 2. 이미지 업로드 처리
+    // 2. CloudFront 도메인 주입
+    @Value("${aws.cloudfront.domain}")
+    private String cloudFrontDomain;
+
+    // 3. 이미지 업로드 처리 로직
     public String uploadImage(MultipartFile file) {
-        // 3. 파일명 중복 방지를 위한 랜덤 이름 생성
-        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
-
-        try {
-            // 4. S3로 파일 스트림 전송
-            s3Template.upload(bucket, fileName, file.getInputStream());
-        } catch (IOException e) {
-            // 5. 예외 발생 시 런타임 예외로 던짐 (GlobalExceptionHandler가 처리)
-            throw new IllegalArgumentException("이미지 업로드 중 오류가 발생했습니다.");
+        // 4. 확장자 추출 (파일명 은닉을 위해 필요)
+        String originalFilename = file.getOriginalFilename();
+        String extension = "";
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
         }
 
-        // 6. 퍼블릭 읽기가 가능한 URL 반환
-        return String.format("https://%s.s3.ap-northeast-2.amazonaws.com/%s", bucket, fileName);
+        // 5. 원본 파일명을 완전히 숨긴 새로운 랜덤 파일명 생성
+        String fileName = UUID.randomUUID().toString() + extension;
+
+        // 6. 혹시 모를 설정값 공백 제거
+        String cleanBucketName = bucket.trim();
+
+        // 7. 로그 확인
+        System.out.println("업로드 시도 버킷: [" + cleanBucketName + "]");
+        System.out.println("생성된 파일명: " + fileName);
+
+        try {
+            // 8. S3로 파일 스트림 전송
+            s3Template.upload(cleanBucketName, fileName, file.getInputStream());
+        } catch (IOException e) {
+            // 9. 예외 발생 시 스택 트레이스 출력 및 예외 던짐
+            e.printStackTrace();
+            throw new IllegalArgumentException("이미지 업로드 중 오류가 발생했습니다: " + e.getMessage());
+        }
+
+        // 10. CloudFront 주소로 반환
+        return String.format("https://%s/%s", cloudFrontDomain, fileName);
     }
 }

--- a/src/main/java/com/example/backend/global/config/s3/S3Service.java
+++ b/src/main/java/com/example/backend/global/config/s3/S3Service.java
@@ -1,0 +1,37 @@
+package com.example.backend.global.config.s3;
+
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Template s3Template;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket; // 1. yusiyeong-media-bucket-2026 주입
+
+    // 2. 이미지 업로드 처리
+    public String uploadImage(MultipartFile file) {
+        // 3. 파일명 중복 방지를 위한 랜덤 이름 생성
+        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+        try {
+            // 4. S3로 파일 스트림 전송
+            s3Template.upload(bucket, fileName, file.getInputStream());
+        } catch (IOException e) {
+            // 5. 예외 발생 시 런타임 예외로 던짐 (GlobalExceptionHandler가 처리)
+            throw new IllegalArgumentException("이미지 업로드 중 오류가 발생했습니다.");
+        }
+
+        // 6. 퍼블릭 읽기가 가능한 URL 반환
+        return String.format("https://%s.s3.ap-northeast-2.amazonaws.com/%s", bucket, fileName);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,14 @@
 spring.application.name=backend
 
-# ?? ?? ???? ????
+# 1. ???? ?? ??
 spring.profiles.include=secrets
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-# JPA ??
+# 2. JPA ??
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+# 3. AWS ?? ??
+spring.cloud.aws.region.static=ap-northeast-2
+spring.cloud.aws.stack.auto=false


### PR DESCRIPTION
## 🎯 이슈 번호
- #35 

## ⚙️ 변경 내용
- 이미지 업로드 시 프로젝트 내부 폴더가 아닌 AWS S3에 따로 저장

## ✉️ 상세 내용
- AWS S3에 따로 저장함으로써 로컬 서버가 아닌 배포 서버에 이미지가 저장됨.
- 여러 명이서 작업 시, 미디어 관련 작업 효율 상승
- CloudFront 주소를 통한 접속으로 인해 보안 강화

## 🖥️ 테스트
> 이미지 저장 시
<img width="852" height="218" alt="image" src="https://github.com/user-attachments/assets/b6ead8be-b5ec-4eb0-a96b-c85447d2f175" />

> 이미지 저장 시 출력되는 주소 클릭 시
<img width="1437" height="834" alt="image" src="https://github.com/user-attachments/assets/e69ab8b7-60c6-4a94-a932-18af5e51a292" />